### PR TITLE
Updated to match function signatures of new foohid versions.

### DIFF
--- a/test_joypad.py
+++ b/test_joypad.py
@@ -33,7 +33,7 @@ try:
     foohid.destroy("FooHID simple joypad")
 except:
     pass
-foohid.create("FooHID simple joypad", struct.pack('{0}B'.format(len(joypad)), *joypad))
+foohid.create("FooHID simple joypad", struct.pack('{0}B'.format(len(joypad)), *joypad), "SN 123456", 2, 3)
 
 while True:
     x = random.randrange(0,255)

--- a/test_list.py
+++ b/test_list.py
@@ -1,7 +1,7 @@
 import foohid
 
 for i in range(1, 10):
-    foohid.create("FooHID {0}".format(i), "xxx")
+    foohid.create("FooHID {0}".format(i), "xxx", "sn %i" % i, 5, 6)
 
 print(foohid.list())
 

--- a/test_mouse.py
+++ b/test_mouse.py
@@ -35,7 +35,7 @@ try:
     foohid.destroy("FooHID simple mouse")
 except:
     pass
-foohid.create("FooHID simple mouse", struct.pack('{0}B'.format(len(mouse)), *mouse))
+foohid.create("FooHID simple mouse", struct.pack('{0}B'.format(len(mouse)), *mouse), "SN 123456", 2, 3)
 
 while True:
     x = random.randrange(0,255)


### PR DESCRIPTION
This change brings foohid-py into parity with the newer foohid versions.  The tests seem to work perfectly for me now.
